### PR TITLE
V2.1.2 增加db2任务构建支持

### DIFF
--- a/src/views/datax/jdbc-datasource/index.vue
+++ b/src/views/datax/jdbc-datasource/index.vue
@@ -236,6 +236,7 @@ export default {
         { value: 'oracle', label: 'oracle' },
         { value: 'postgresql', label: 'postgresql' },
         { value: 'sqlserver', label: 'sqlserver' },
+        { value: 'db2', label: 'db2' },
         { value: 'hive', label: 'hive' },
         { value: 'hbase', label: 'hbase' },
         { value: 'mongodb', label: 'mongodb' },

--- a/src/views/datax/jdbc-datasource/index.vue
+++ b/src/views/datax/jdbc-datasource/index.vue
@@ -264,6 +264,9 @@ export default {
       } else if (datasource === 'sqlserver') {
         this.temp.jdbcUrl = 'jdbc:sqlserver://{host}:{port};DatabaseName={database}'
         this.temp.jdbcDriverClass = 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+      } else if (datasource === 'db2') {
+        this.temp.jdbcUrl = 'jdbc:db2://{host}[:{port}]/{database}'
+        this.temp.jdbcDriverClass = 'com.ibm.db2.jcc.DB2Driver'
       } else if (datasource === 'clickhouse') {
         this.temp.jdbcUrl = 'jdbc:clickhouse://{host}:{port}/{database}'
         this.temp.jdbcDriverClass = 'ru.yandex.clickhouse.ClickHouseDriver'

--- a/src/views/datax/json-build-batch/reader/tableReader.vue
+++ b/src/views/datax/json-build-batch/reader/tableReader.vue
@@ -11,7 +11,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：">
+      <el-form-item v-show="needSchema" label="Schema：">
         <el-select v-model="readerForm.tableSchema" filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -63,6 +63,7 @@ export default {
       customType: '',
       customValue: '',
       dataSource: '',
+      needSchema:false,
       readerForm: {
         datasourceId: undefined,
         tables: [],
@@ -81,8 +82,10 @@ export default {
     'readerForm.datasourceId': function(oldVal, newVal) {
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+        this.needSchema = true
       } else {
         this.getTables('reader')
+        this.needSchema = false
       }
     }
   },
@@ -96,6 +99,13 @@ export default {
       jdbcDsList(this.jdbcDsQuery).then(response => {
         const { records } = response
         this.rDsList = records
+        this.dataSource = this.rDsList[0].datasource
+        this.readerForm.datasourceId = this.rDsList[0].id;
+        if(this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2'){
+           this.needSchema = true;
+        }else{
+          this.needSchema = false;
+        }
         this.loading = false
       })
     },
@@ -103,7 +113,7 @@ export default {
     getTables(type) {
       if (type === 'reader') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
+        if (this.needSchema) {
           obj = {
             datasourceId: this.readerForm.datasourceId,
             tableSchema: this.readerForm.tableSchema

--- a/src/views/datax/json-build-batch/reader/tableReader.vue
+++ b/src/views/datax/json-build-batch/reader/tableReader.vue
@@ -11,7 +11,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver'" label="Schema：">
+      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：">
         <el-select v-model="readerForm.tableSchema" filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -79,7 +79,7 @@ export default {
   },
   watch: {
     'readerForm.datasourceId': function(oldVal, newVal) {
-      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       } else {
         this.getTables('reader')
@@ -103,7 +103,7 @@ export default {
     getTables(type) {
       if (type === 'reader') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
           obj = {
             datasourceId: this.readerForm.datasourceId,
             tableSchema: this.readerForm.tableSchema
@@ -147,8 +147,9 @@ export default {
       })
       Bus.dataSourceId = e
       this.$emit('selectDataSource', this.dataSource)
-      // 获取可用表
-      this.getTables('reader')
+      // 切换数据源时，清空可用表列表,当需要选择schemas时，先选择schemas再加载表
+      this.readerForm.tableSchema = ''
+      this.rTbList = []
     },
     rHandleCheckAllChange(val) {
       this.readerForm.tables = val ? this.rTbList : []

--- a/src/views/datax/json-build-batch/reader/tableReader.vue
+++ b/src/views/datax/json-build-batch/reader/tableReader.vue
@@ -138,7 +138,7 @@ export default {
     // reader 数据源切换
     rDsChange(e) {
       // 清空
-      this.readerForm.tableName = ''
+      this.readerForm.tables = []
       this.readerForm.datasourceId = e
       this.rDsList.find((item) => {
         if (item.id === e) {

--- a/src/views/datax/json-build-batch/writer/tableWriter.vue
+++ b/src/views/datax/json-build-batch/writer/tableWriter.vue
@@ -129,7 +129,7 @@ export default {
     },
     wDsChange(e) {
       // 清空
-      this.writerForm.tableName = ''
+      this.writerForm.tables = []
       this.writerForm.datasourceId = e
       this.wDsList.find((item) => {
         if (item.id === e) {

--- a/src/views/datax/json-build-batch/writer/tableWriter.vue
+++ b/src/views/datax/json-build-batch/writer/tableWriter.vue
@@ -16,7 +16,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：">
+      <el-form-item v-show="needSchema" label="Schema：">
         <el-select v-model="writerForm.tableSchema" filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -56,6 +56,7 @@ export default {
       fromTableName: '',
       wTbList: [],
       dataSource: '',
+      needSchema:false,
       createTableName: '',
       writerForm: {
         datasourceId: undefined,
@@ -75,8 +76,10 @@ export default {
     'writerForm.datasourceId': function(oldVal, newVal) {
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+        this.needSchema = true
       } else {
         this.getTables('writer')
+        this.needSchema = false
       }
     }
   },
@@ -90,6 +93,13 @@ export default {
       jdbcDsList(this.jdbcDsQuery).then(response => {
         const { records } = response
         this.wDsList = records
+        this.dataSource = this.wDsList[0].datasource
+        this.writerForm.datasourceId = this.wDsList[0].id;
+        if(this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2'){
+           this.needSchema = true;
+        }else{
+          this.needSchema = false;
+        }
         this.loading = false
       })
     },
@@ -97,7 +107,7 @@ export default {
     getTables(type) {
       if (type === 'writer') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
+        if (this.needSchema) {
           obj = {
             datasourceId: this.writerForm.datasourceId,
             tableSchema: this.writerForm.tableSchema

--- a/src/views/datax/json-build-batch/writer/tableWriter.vue
+++ b/src/views/datax/json-build-batch/writer/tableWriter.vue
@@ -16,7 +16,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver'" label="Schema：">
+      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：">
         <el-select v-model="writerForm.tableSchema" filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -73,7 +73,7 @@ export default {
   },
   watch: {
     'writerForm.datasourceId': function(oldVal, newVal) {
-      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       } else {
         this.getTables('writer')
@@ -97,7 +97,7 @@ export default {
     getTables(type) {
       if (type === 'writer') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
           obj = {
             datasourceId: this.writerForm.datasourceId,
             tableSchema: this.writerForm.tableSchema
@@ -138,8 +138,9 @@ export default {
       })
       Bus.dataSourceId = e
       this.$emit('selectDataSource', this.dataSource)
-      // 获取可用表
-      this.getTables()
+      // 切换数据源时，清空可用表列表，当需要选择schemas时，先选择schemas再加载表
+      this.writerForm.tableSchema = ''
+      this.wTbList = []
     },
     wHandleCheckAllChange(val) {
       this.writerForm.tables = val ? this.wTbList : []

--- a/src/views/datax/json-build/reader/RDBMSReader.vue
+++ b/src/views/datax/json-build/reader/RDBMSReader.vue
@@ -96,11 +96,12 @@ export default {
   },
   watch: {
     'readerForm.datasourceId': function(oldVal, newVal) {
+      // 当需要选择schemas时，先选择schemas再加载表
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+      } else {
+        this.getTables('rdbmsReader')
       }
-      // 当需要选择schemas时，先选择schemas再加载表
-      // this.getTables('rdbmsReader')
     }
   },
   created() {
@@ -164,6 +165,9 @@ export default {
       })
       Bus.dataSourceId = e
       this.$emit('selectDataSource', this.dataSource)
+      // 切换数据源时，清空可用表列表,当需要选择schemas时，先选择schemas再加载表
+      this.readerForm.tableSchema = ''
+      this.rTbList = []
     },
     getTableColumns() {
       const obj = {

--- a/src/views/datax/json-build/reader/RDBMSReader.vue
+++ b/src/views/datax/json-build/reader/RDBMSReader.vue
@@ -11,7 +11,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver'" label="Schema：" prop="tableSchema">
+      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：" prop="tableSchema">
         <el-select v-model="readerForm.tableSchema" allow-create default-first-option filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -96,10 +96,11 @@ export default {
   },
   watch: {
     'readerForm.datasourceId': function(oldVal, newVal) {
-      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       }
-      this.getTables('rdbmsReader')
+      //当需要选择schemas时，先选择schemas再加载表
+      //this.getTables('rdbmsReader')
     }
   },
   created() {
@@ -119,7 +120,7 @@ export default {
     getTables(type) {
       if (type === 'rdbmsReader') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
           obj = {
             datasourceId: this.readerForm.datasourceId,
             tableSchema: this.readerForm.tableSchema

--- a/src/views/datax/json-build/reader/RDBMSReader.vue
+++ b/src/views/datax/json-build/reader/RDBMSReader.vue
@@ -99,8 +99,8 @@ export default {
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       }
-      //当需要选择schemas时，先选择schemas再加载表
-      //this.getTables('rdbmsReader')
+      // 当需要选择schemas时，先选择schemas再加载表
+      // this.getTables('rdbmsReader')
     }
   },
   created() {

--- a/src/views/datax/json-build/reader/RDBMSReader.vue
+++ b/src/views/datax/json-build/reader/RDBMSReader.vue
@@ -11,7 +11,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver' ||dataSource==='db2'" label="Schema：" prop="tableSchema">
+      <el-form-item v-show="needSchema" label="Schema：" prop="tableSchema">
         <el-select v-model="readerForm.tableSchema" allow-create default-first-option filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -76,6 +76,7 @@ export default {
       customType: '',
       customValue: '',
       dataSource: '',
+      needSchema:false,
       readerForm: {
         datasourceId: undefined,
         tableName: '',
@@ -99,8 +100,10 @@ export default {
       // 当需要选择schemas时，先选择schemas再加载表
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+        this.needSchema = true
       } else {
         this.getTables('rdbmsReader')
+        this.needSchema = false
       }
     }
   },
@@ -114,6 +117,13 @@ export default {
       jdbcDsList(this.jdbcDsQuery).then(response => {
         const { records } = response
         this.rDsList = records
+        this.dataSource = this.rDsList[0].datasource
+        this.readerForm.datasourceId = this.rDsList[0].id;
+        if(this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2'){
+           this.needSchema = true;
+        }else{
+          this.needSchema = false;
+        }
         this.loading = false
       })
     },
@@ -121,7 +131,7 @@ export default {
     getTables(type) {
       if (type === 'rdbmsReader') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
+        if (this.needSchema) {
           obj = {
             datasourceId: this.readerForm.datasourceId,
             tableSchema: this.readerForm.tableSchema

--- a/src/views/datax/json-build/writer/RDBMSWriter.vue
+++ b/src/views/datax/json-build/writer/RDBMSWriter.vue
@@ -106,11 +106,12 @@ export default {
   },
   watch: {
     'writerForm.datasourceId': function(oldVal, newVal) {
+      // 当需要选择schemas时，先选择schemas再加载表
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+      } else {
+        this.getTables('rdbmsWriter')
       }
-      // 当需要选择schemas时，先选择schemas再加载表
-      // this.getTables('rdbmsWriter')
     }
   },
   created() {
@@ -162,6 +163,7 @@ export default {
     },
     wDsChange(e) {
       // 清空
+      this.fromTableName = ''
       this.writerForm.tableName = ''
       this.writerForm.datasourceId = e
       this.wDsList.find((item) => {
@@ -171,6 +173,9 @@ export default {
       })
       Bus.dataSourceId = e
       this.$emit('selectDataSource', this.dataSource)
+      // 切换数据源时，清空可用表列表，当需要选择schemas时，先选择schemas再加载表
+      this.writerForm.tableSchema = ''
+      this.wTbList = []
     },
     // 获取表字段
     getColumns() {

--- a/src/views/datax/json-build/writer/RDBMSWriter.vue
+++ b/src/views/datax/json-build/writer/RDBMSWriter.vue
@@ -109,8 +109,8 @@ export default {
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       }
-      //当需要选择schemas时，先选择schemas再加载表
-      //this.getTables('rdbmsWriter')
+      // 当需要选择schemas时，先选择schemas再加载表
+      // this.getTables('rdbmsWriter')
     }
   },
   created() {

--- a/src/views/datax/json-build/writer/RDBMSWriter.vue
+++ b/src/views/datax/json-build/writer/RDBMSWriter.vue
@@ -16,7 +16,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' ||dataSource==='sqlserver'" label="Schema：" prop="tableSchema">
+      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' || dataSource==='sqlserver' || dataSource==='db2'" label="Schema：" prop="tableSchema">
         <el-select v-model="writerForm.tableSchema" allow-create default-first-option filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -106,10 +106,11 @@ export default {
   },
   watch: {
     'writerForm.datasourceId': function(oldVal, newVal) {
-      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+      if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
       }
-      this.getTables('rdbmsWriter')
+      //当需要选择schemas时，先选择schemas再加载表
+      //this.getTables('rdbmsWriter')
     }
   },
   created() {
@@ -129,7 +130,7 @@ export default {
     getTables(type) {
       if (type === 'rdbmsWriter') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver') {
+        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
           obj = {
             datasourceId: this.writerForm.datasourceId,
             tableSchema: this.writerForm.tableSchema

--- a/src/views/datax/json-build/writer/RDBMSWriter.vue
+++ b/src/views/datax/json-build/writer/RDBMSWriter.vue
@@ -16,7 +16,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item v-show="dataSource==='postgresql' || dataSource==='oracle' || dataSource==='sqlserver' || dataSource==='db2'" label="Schema：" prop="tableSchema">
+      <el-form-item v-show="needSchema" label="Schema：" prop="tableSchema">
         <el-select v-model="writerForm.tableSchema" allow-create default-first-option filterable style="width: 300px" @change="schemaChange">
           <el-option
             v-for="item in schemaList"
@@ -84,6 +84,7 @@ export default {
       fromColumnList: [],
       wTbList: [],
       dataSource: '',
+      needSchema:false,
       createTableName: '',
       writerForm: {
         datasourceId: undefined,
@@ -109,8 +110,10 @@ export default {
       // 当需要选择schemas时，先选择schemas再加载表
       if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
         this.getSchema()
+        this.needSchema = true
       } else {
         this.getTables('rdbmsWriter')
+        this.needSchema = false
       }
     }
   },
@@ -124,6 +127,13 @@ export default {
       jdbcDsList(this.jdbcDsQuery).then(response => {
         const { records } = response
         this.wDsList = records
+        this.dataSource = this.wDsList[0].datasource
+        this.writerForm.datasourceId = this.wDsList[0].id;
+        if(this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2'){
+           this.needSchema = true;
+        }else{
+          this.needSchema = false;
+        }
         this.loading = false
       })
     },
@@ -131,7 +141,7 @@ export default {
     getTables(type) {
       if (type === 'rdbmsWriter') {
         let obj = {}
-        if (this.dataSource === 'postgresql' || this.dataSource === 'oracle' || this.dataSource === 'sqlserver' || this.dataSource === 'db2') {
+        if (this.needSchema) {
           obj = {
             datasourceId: this.writerForm.datasourceId,
             tableSchema: this.writerForm.tableSchema


### PR DESCRIPTION
1、增加DB2任务构建
2、当需要选择schemas时，先选择schemas再加载表，减少前后端交互次数
3、修复批量创建任务，切换数据源时已选择的表列表未清空的问题
4、修复默认选中数据源schemas下拉框显示不正常的问题