### PR TITLE
资源监控界面添加分页组件

### DIFF
--- a/src/views/datax/registry/index.vue
+++ b/src/views/datax/registry/index.vue
@@ -15,16 +15,25 @@
         <p class="number">{{ item.loadAverage >= 0 ? item.loadAverage : 0 }}</p>
       </div>
     </div>
+    <pagination
+      v-show="total>0"
+      :total="total"
+      :page.sync="listQuery.current"
+      :limit.sync="listQuery.size"
+      @pagination="fetchData"
+    />
   </div>
 </template>
 
 <script>
 import { getList } from '@/api/datax-registry'
 import waves from '@/directive/waves' // waves directive
+import Pagination from '@/components/Pagination'
 
 export default {
   name: 'Registry',
   directives: { waves },
+  components: { Pagination },
   filters: {
     statusFilter(status) {
       const statusMap = {


### PR DESCRIPTION
默认资源管理界面只能展示10个机器信息，当超过10个后无法分页展示